### PR TITLE
fix(ci): restrict workflow_dispatch production deploys to main

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: ${{ github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 30
@@ -25,6 +26,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'refs/heads/main' || github.sha }}
 
       - name: Load versioned Hetzner deploy config
         run: |


### PR DESCRIPTION
### Motivation
- The production deploy workflow allowed `workflow_dispatch` runs to check out and execute code from an arbitrary ref while exposing production secrets, enabling attacker-controlled branch execution during deployment.
- The change aims to ensure deployment commands and secrets are only used with trusted `main`-sourced code.

### Description
- Added a job-level guard `if: ${{ github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main' }}` to the `deploy` job in `/.github/workflows/deploy-production.yml` so manual dispatches only proceed when the selected ref is `refs/heads/main`.
- Pinned the checkout ref for manual runs by setting `ref: ${{ github.event_name == 'workflow_dispatch' && 'refs/heads/main' || github.sha }}` in the `actions/checkout` step to ensure deployed code always comes from `main` for manual deploys.
- The only modified file is `/.github/workflows/deploy-production.yml` and the change is intentionally minimal to preserve existing deployment behavior for trusted refs.

### Testing
- Ran `mise trust mise.toml` successfully as required by project tooling.
- Attempted `bin/ci` but it failed because `mise` could not install the pinned Ruby toolchain (`ruby@4.0.2`) due to external network/toolchain fetch failures, so full CI checks could not complete in this environment.
- No automated tests were added or changed because the fix is limited to the GitHub Actions workflow YAML.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0adcc59d8c832b9b1f2f88fd069152)