### PR TITLE
fix(security): block SSRF targets in LLM link validator

### DIFF
--- a/app/services/importing/llm_enrichment/link_validator.rb
+++ b/app/services/importing/llm_enrichment/link_validator.rb
@@ -1,5 +1,6 @@
 require "net/http"
 require "uri"
+require "ipaddr"
 
 module Importing
   module LlmEnrichment
@@ -150,6 +151,7 @@ module Importing
         uri = URI.parse(value)
         return unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
         return if uri.host.blank?
+        return if blocked_host?(uri.host)
 
         uri
       rescue URI::InvalidURIError
@@ -191,6 +193,12 @@ module Importing
             ) if redirects > REDIRECT_LIMIT
 
             current_uri = current_uri.merge(location)
+            return rejected_result(
+              status: "rejected_invalid_url",
+              original_url: original_url,
+              final_url: current_uri,
+              http_status: code
+            ) if blocked_host?(current_uri.host)
           when 404, 410
             return rejected_result(
               status: "rejected_http_error",
@@ -219,6 +227,18 @@ module Importing
             )
           end
         end
+      end
+
+      def blocked_host?(host)
+        normalized_host = host.to_s.downcase
+        return true if normalized_host.blank? || normalized_host == "localhost"
+
+        ip = IPAddr.new(normalized_host)
+        return true if ip.loopback? || ip.private? || ip.link_local? || ip.multicast? || ip.unspecified?
+
+        false
+      rescue IPAddr::InvalidAddressError
+        false
       end
 
       def perform_get(uri)

--- a/test/services/importing/llm_enrichment/link_validator_test.rb
+++ b/test/services/importing/llm_enrichment/link_validator_test.rb
@@ -253,6 +253,36 @@ module Importing
         assert_equal "rejected_invalid_url", result.status
       end
 
+      test "rejects localhost and private ip urls" do
+        validator = build_validator
+
+        localhost_result = validator.call(url: "http://localhost/internal", field_name: :homepage_link)
+        loopback_result = validator.call(url: "http://127.0.0.1/internal", field_name: :homepage_link)
+        metadata_result = validator.call(url: "http://169.254.169.254/latest/meta-data", field_name: :homepage_link)
+
+        assert_equal false, localhost_result.accepted?
+        assert_equal "rejected_invalid_url", localhost_result.status
+        assert_equal false, loopback_result.accepted?
+        assert_equal "rejected_invalid_url", loopback_result.status
+        assert_equal false, metadata_result.accepted?
+        assert_equal "rejected_invalid_url", metadata_result.status
+      end
+
+      test "rejects redirects to blocked hosts" do
+        validator = build_validator(
+          "https://example.com/start" => FakeResponse.new(
+            code: "302",
+            body: "",
+            headers: { "location" => "http://127.0.0.1/internal" }
+          )
+        )
+
+        result = validator.call(url: "https://example.com/start", field_name: :homepage_link)
+
+        assert_equal false, result.accepted?
+        assert_equal "rejected_invalid_url", result.status
+      end
+
       private
 
       def build_validator(responses = {})


### PR DESCRIPTION
### Motivation
- Closing a blind-SSRF vector where untrusted imported `event_info` could prompt the LLM to return internal or metadata URLs which the backend then fetched without network-range restrictions.  
- Keep remediation minimal and sink-side: harden URL validation in `LinkValidator` to refuse requests to internal/loopback/link-local IPs and `localhost` before any network connect.  

### Description
- Added `require "ipaddr"` and a `blocked_host?(host)` helper that rejects `localhost` and IP-literal hosts that are loopback, private, link-local, multicast, or unspecified.  
- `parse_http_uri` now returns nil for blocked hosts so they are treated as invalid URLs.  
- `follow_redirects` checks redirect hops and rejects any hop that resolves to a blocked host before attempting further fetches.  
- Added unit tests in `test/services/importing/llm_enrichment/link_validator_test.rb` that assert rejection of direct blocked URLs (`localhost`, `127.0.0.1`, `169.254.169.254`) and of redirects that point to blocked hosts.  
- Files changed: `app/services/importing/llm_enrichment/link_validator.rb`, `test/services/importing/llm_enrichment/link_validator_test.rb`.  

### Testing
- Added automated unit tests exercising the new blocked-host behavior; these tests are included in `test/services/importing/llm_enrichment/link_validator_test.rb`.  
- Attempted to run the RuboCop linter with `mise exec -- bundle exec rubocop app/services/importing/llm_enrichment/link_validator.rb test/services/importing/llm_enrichment/link_validator_test.rb`, but `mise` failed to install toolchains due to transient network/toolchain bootstrap errors so linting could not complete in this environment.  
- Recommend CI run `bin/ci` (or locally `mise exec -- bin/ci`) to execute the full test and lint pipeline before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac93ac6c4832bab9eaa4d3f2a8cf3)